### PR TITLE
CVE-2012-0857 and CVE-2014-8541

### DIFF
--- a/cves/CVE-2012-0857.yml
+++ b/cves/CVE-2012-0857.yml
@@ -22,7 +22,7 @@ curated_instructions: |
 
   The latest curation level is 1.0.
   If you are curating this vulnerability, set it to the latest curation level.
-curation_level: 0.0
+curation_level: 1.0
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins, bug reports, commit messages of the fix.
@@ -31,7 +31,7 @@ reported_instructions: |
   you can't find it out.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2012-08-20
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -43,11 +43,11 @@ announced_instructions: |
 
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2012-02-01
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2012-01-04
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -64,7 +64,12 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  A library function #get_qcx(..., int n, ...), in libavcodec, allowed an input n that would
+  cause numerous buffer overflows, causing ffmpeg to crash. Note the fix was fairly rough,
+  merely adding a check if n was greater than 96. Essentially, this exploit could be triggered
+  by attempting to decode an image with very small dimensions. It should be mentioned this
+  overflow does not expose integrity or confidentiality concerns.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -79,7 +84,7 @@ bugs_instructions: |
   Sometimes a commit message will mention a bug, or the security page on FFmpeg.
   Sometimes you need to search bug database, which is here:
       https://trac.ffmpeg.org
-bugs: []
+bugs: [ ]
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" field below (see my example in
   CVE-2011-3092.yml).
@@ -89,15 +94,15 @@ fixes_vcc_instructions: |
   The notes field is optional - place anything that clarifies things or you
   find interesting in there.
 fixes:
-- commit: 282bb02839b1ce73963c8e3ee46804f1ade8b12a
-  note: ''
-- commit: ''
-  note: ''
+  - commit: 282bb02839b1ce73963c8e3ee46804f1ade8b12a
+    note: ''
+  - commit: ''
+    note: ''
 vccs:
-- commit: 83654c7b1b598add9041c7add6b77478eb91177f
-  note: Identified by archeogit,Identified by SZZUnleashed
-- commit: ''
-  note: ''
+  - commit: 83654c7b1b598add9041c7add6b77478eb91177f
+    note: Identified by archeogit,Identified by SZZUnleashed
+  - commit: ''
+    note: ''
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -125,7 +130,17 @@ lifetime:
           git log --stat abc..def -- your/file.c
           (where a)
       * the changelog between the two
-  answer:
+  answer: |
+    VCC Date: Mon May 23 23:13:34 2011 +0200
+    Fix Date: Sat Dec 24 06:17:12 2011 +0100
+    Lifetime: ~7 months
+
+    All maintainence code committed were signed by a single developer (michaelni@gmx.at),
+    which were added to fix code initially made by (rukhsana.afroz@gmail.com).
+    The initial code was introduced as "shouldn't be left to rot" on another repository,
+    and from there received nothing but bugfix commits (sometimes addressing the same issue)
+    up until the final resolving commit. The project itself was largely undergoing frequent changes
+    after the initial 0.5.0 release (where their beta versioning started taking off).
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -144,10 +159,13 @@ unit_tested:
     In FFmpeg, they have the FATE suite of regression tests. They are not
     "unit" tests per se, but are automated regression tests. If the fix for the
     vulnerability involved adding or updating a FATE suite, then make fix: true.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false
+  code_answer: |
+    No automated unit/regression tests nearby (possibly related: avcodec/tests/jpeg2000dwt.c),
+    and no updates to them in fixes. A brief alude to fate-j2k-dwt inside of libavcodec.mak,
+    which could potentially serve as an existing test for this system in some capacity.
+  fix: false
+  fix_answer: Fix simply appended an OR check onto the bounds checks
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -167,10 +185,14 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked. Thus, 'answer' should always have some
     explanation.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: |
+    Security Vulnerability was reported by a non-involved author through use of
+    an automated tool (e.g. valgrind) to find faulty memory accesses.
+
+    Relevant email: https://www.openwall.com/lists/oss-security/2012/02/01/11
+  automated: true
+  contest: false
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -186,8 +208,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: |
+    Due to the error arising from the decoding of a small (or even empty) jpeg
+    input stream, this bug could be potentially found in any system that feeds
+    user input (in file form or otherwise) to ffmpeg to be decoded.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example,
@@ -199,8 +224,9 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: |
+    Bug was noticed via an automated tool, reported, and manually patched.
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -236,8 +262,8 @@ subsystem:
     If this involves fixing multiple subsystems, you can make this an array.
 
     In 'answer', explain how you arrived at this determination.
-  answer:
-  name:
+  answer: "It's very clearly a bug with the j2kdec.c (JPEG-2000 decoder) file, located in libavcodec"
+  name: avcodec
 interesting_commits:
   question: |
     Optional: are there any interesting commits between your VCC(s) and fix(es)?
@@ -253,10 +279,14 @@ interesting_commits:
       * A change that looks really sketchy
       * Commits where a developer mentions security in their message or comments
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+    - commit: 3eedf9f716733b3b4c5205726d2c1ca52b3d3d78
+      note: 'while not between vcc->fix, our reference about j2k being experimental'
+    - commit: 2fbf69103847d9449de466fa217f8bd4221aa3e9
+      note: "bit of a startling mistake: 'Fix use of value before its initialized.'"
+    - commit: 02660a871301adada14b0e0fe64c66f73c2e4541
+      note: "seems a fix was attempted before: 'Check for out of bound reads in jpeg 2000 decoder.'"
+    - commit: 454f1657288e75a9797381c8a26598674ea9bd68
+      note: "something that shouldn't have been there to begin with: 'fix a bunch of const compiler warnings'"
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -266,8 +296,8 @@ i18n:
 
     Answer should be boolean. Write a note about how you came to the conclusions
     you did.
-  answer:
-  note:
+  answer: false
+  note: Feature was for image (JPEG2000 / J2K) decoding
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -276,8 +306,8 @@ ipc:
     software system reads is another form of IPC.
 
     Answer should be boolean.
-  answer:
-  note:
+  answer: true
+  note: The get_qcx function call interacts with J2kDecoderContext (user input stream)
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -306,8 +336,8 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: Erroneously small or empty user inputs caused this crash
   security_by_obscurity:
     applies:
     note:
@@ -321,11 +351,13 @@ lessons:
     applies:
     note:
   yagni:
-    applies:
-    note:
+    applies: true
+    note: |
+      In essence, this decoder was imported simply because it was available,
+      rather than being assessed for its quality.
   complex_inputs:
-    applies:
-    note:
+    applies: true
+    note: Images easily fall under complex inputs, a mismatched dimension here caused the crash
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -342,7 +374,12 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    It appears that the initial code was adopted without much testing or review,
+    as many of the issues that arose over the years related to this module were very
+    simple bounds checks and lack of initializers. Perhaps an overzealous strategy
+    towards adding encoder/decoder compatibility led to some of the encoder/decoder
+    classes being fraught with these kinds of issues.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -355,11 +392,11 @@ CWE_instructions: |
 
   Just the number here is fine. No need for name or CWE prefix. If more than one
   apply here, then choose the best one and mention the others in CWE_note.
-CWE:
+CWE: 119
 CWE_note:
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it. If the
   report mentions a nickname, e.g. "Heartbleed", use that. Or come up with one!
 
   Must be under 30 characters. Optional. Be appropriate.
-nickname:
+nickname: J0Ker

--- a/cves/CVE-2014-8541.yml
+++ b/cves/CVE-2014-8541.yml
@@ -22,7 +22,7 @@ curated_instructions: |
 
   The latest curation level is 1.0.
   If you are curating this vulnerability, set it to the latest curation level.
-curation_level: 0.0
+curation_level: 1.0
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins, bug reports, commit messages of the fix.
@@ -31,7 +31,7 @@ reported_instructions: |
   you can't find it out.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2014-11-05
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -43,11 +43,11 @@ announced_instructions: |
 
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2014-10-24
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2014-12-03
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -64,7 +64,12 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  A vulnerability in mpeg video decoding, where the decoder will only keep track
+  of image size changes through the set "dimensions" of each frame's image (and
+  not accounting for the "bits per pixel" of the frame). This allows remote attackers
+  to make use of data with non-standard bytes-per-pixel in order to over or underflow
+  the backing memory buffer.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -90,16 +95,16 @@ fixes_vcc_instructions: |
   find interesting in there.
 fixes:
 - commit: 5c378d6a6df8243f06c87962b873bd563e58cd39
-  note: ''
+  note: 'Found By: Mateusz "j00ru" Jurczyk and Gynvael Coldwind'
 - commit: ''
   note: ''
 vccs:
 - commit: 4922a5b0ee9108e406b8b14356f19851702604d1
-  note: Identified by archeogit,Identified by SZZUnleashed
-- commit: 406792e7b0f15627411728829c7a2de86fcbe96b
-  note: Identified by SZZUnleashed
+  note: Identified by archeogit,Identified by SZZUnleashed, refactoring
+- commit: 10b7b472d99b8db3fba287388294dae7ce89f152
+  note: The earliest point in the mpeg-coder history that decoding was added w/ the bug
 - commit: ''
-  note: ''
+note: ''
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -127,7 +132,19 @@ lifetime:
           git log --stat abc..def -- your/file.c
           (where a)
       * the changelog between the two
-  answer:
+  answer: |
+    VCC1 Date:  Thu May 17 16:29:11 2007 +0000
+    VCC2 Date:  Mon Jan 19 15:46:40 2009 +0000
+    Fix Date:   Fri Oct 3 01:50:27 2014 +0200
+    Lifetime:   ~7 years
+
+    Code has seen frequent and active development, with the project openly
+    accepting PRs (and thus having collaborative code from 34 different authors,
+    within the timeframe of VCC1->Fix). A majority of this commits are still
+    michaelni (200+), with four other developers having over 10 commits to the
+    history in this timeframe. FFMpeg itself went through several early revisions,
+    beta and initial releases, and several lifecycle phases before this issue was
+    fully addressed.
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -146,10 +163,10 @@ unit_tested:
     In FFmpeg, they have the FATE suite of regression tests. They are not
     "unit" tests per se, but are automated regression tests. If the fix for the
     vulnerability involved adding or updating a FATE suite, then make fix: true.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false
+  code_answer: No automated/regression tests, no updates to them in fixes.
+  fix: false
+  fix_answer: Code was updated/fixed directly, no FATE suite
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -169,10 +186,14 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked. Thus, 'answer' should always have some
     explanation.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: |
+    End-user of the software had a file which failed to properly decode (caused a
+    buffer overflow). While I could not find an attached ticket/issue, it seems
+    there had been previous communication of this file, as well as previous commits
+    concerning it. Thus it was essentially discovered through trial-and-error / community feedback.
+  automated: false
+  contest: false
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -188,8 +209,8 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: false
+  answer: Requires specifically crafted input, more likely to be found accidentally
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example,
@@ -201,8 +222,11 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: false
+  answer: |
+    While I could not find any explicit reference to a standard or specification,
+    the crash did center around the format for input MPEG-video frames, which is
+    likely standardized and published somewhere.
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -238,8 +262,10 @@ subsystem:
     If this involves fixing multiple subsystems, you can make this an array.
 
     In 'answer', explain how you arrived at this determination.
-  answer:
-  name:
+  answer: |
+    The video decoder for .avi/mpeg (MJpegDecodeContent) is handled within mjpegdec.c,
+    safely within libavcodec (which handles encoding/decoding specifications).
+  name: avcodec
 interesting_commits:
   question: |
     Optional: are there any interesting commits between your VCC(s) and fix(es)?
@@ -255,10 +281,10 @@ interesting_commits:
       * A change that looks really sketchy
       * Commits where a developer mentions security in their message or comments
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+  - commit: 0db1f2c2c78db18999fccd46a156408e5e87c8a1
+    note: 'A related commit, perhaps early attempts at a fix/debugging'
+  - commit: ''
+    note: ''
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -268,8 +294,12 @@ i18n:
 
     Answer should be boolean. Write a note about how you came to the conclusions
     you did.
-  answer:
-  note:
+  answer: false
+  note: |
+    A little torn on this option, while the various types (and implementations)
+    of codecs is itself an internationalization issue, I would not say that this specific
+    issue arises from internationalization concerns (of relation to character sets, text
+    encoding, etc).
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -278,8 +308,10 @@ ipc:
     software system reads is another form of IPC.
 
     Answer should be boolean.
-  answer:
-  note:
+  answer: true
+  note: |
+    Absolutely, interacts with MJpegDecodeContext, which is fed from user input, and
+    then output to any variety of locations specified by the end-user.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -296,8 +328,12 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
-    note:
+    applies: true
+    note: |
+      In this sense, defense in depth would be good to apply
+      towards the encoder/decoder modules, as failure within a module
+      could be isolated and reported. Particularly as these are
+      open-source modules, some isolation is desired.
   least_privilege:
     applies:
     note:
@@ -308,8 +344,12 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: |
+      As always, if this system is user-facing and accepts input, it will
+      likely be compromised if it is capable of being so. In this case,
+      once a user has found an input that crashes the system, there's no
+      stopping them from holding down the service.
   security_by_obscurity:
     applies:
     note:
@@ -326,8 +366,8 @@ lessons:
     applies:
     note:
   complex_inputs:
-    applies:
-    note:
+    applies: true
+    note: Videos easily fall under complex inputs, codec-specific information caused this crash
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -344,7 +384,12 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    Quite an old bug on this one! In truth, I think some more stringent
+    controls in terms of unit testing as well as testing a larger variety of
+    inputs would benefit in seeing some of the pitfalls. More importantly,
+    these tests need to be kept up-to-date with current standards involved
+    with the codecs' formats.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -357,11 +402,11 @@ CWE_instructions: |
 
   Just the number here is fine. No need for name or CWE prefix. If more than one
   apply here, then choose the best one and mention the others in CWE_note.
-CWE:
+CWE: 119
 CWE_note:
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it. If the
   report mentions a nickname, e.g. "Heartbleed", use that. Or come up with one!
 
   Must be under 30 characters. Optional. Be appropriate.
-nickname:
+nickname: MPegged

--- a/cves/CVE-2017-17081.yml
+++ b/cves/CVE-2017-17081.yml
@@ -31,8 +31,8 @@ reported_instructions: |
   you can't find it out.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
-announced_instructions: |
+reported_date: 2017-11-30
+lannounced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
 
@@ -43,11 +43,11 @@ announced_instructions: |
 
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2017-11-15
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2017-12-10
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -64,7 +64,14 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  NOTE: This third file was accidentally started - disregard (or don't if you're feeling extra credit-y?)
+
+  The library does not properly authetnicate widths and heights of a passed-in
+  MPEG stream. An attacker can utilize this to craft a video which has actual
+  width/heights (in-content) less than specified (causing a signedness error),
+  or by providing a video with content bigger than specified (causing an
+  out-of-array read, a classic variation of a buffer overflow).
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -79,7 +86,9 @@ bugs_instructions: |
   Sometimes a commit message will mention a bug, or the security page on FFmpeg.
   Sometimes you need to search bug database, which is here:
       https://trac.ffmpeg.org
-bugs: []
+bugs: [
+  "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3516#c1"
+]
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" field below (see my example in
   CVE-2011-3092.yml).
@@ -89,6 +98,8 @@ fixes_vcc_instructions: |
   The notes field is optional - place anything that clarifies things or you
   find interesting in there.
 fixes:
+- commit: 6ccf19198b360cfc3fe5cd274948cfde2fe305e0
+  note: 'From ffmpeg security page'
 - commit: 58cf31cee7a456057f337b3102a03206d833d5e8
   note: ''
 - commit: 127a362630e11fe724e2e63fc871791fdcbcfa64
@@ -99,9 +110,11 @@ vccs:
 - commit: d7463c681363d6057601e705d0bf775738529841
   note: Identified by archeogit,Identified by SZZUnleashed
 - commit: fab9df63a3156ffe1f9490aafaea41e03ef60ddf
-  note: Identified by SZZUnleashed
+  note: Identified by SZZUnleashed,  Code refactored, introduced explciit bug
 - commit: 8b5007a31b8d1ddbe3661bf45a732336450b7d25
-  note: Identified by archeogit,
+  note: Identified by archeogit,  Code refactored
+- commit: 703c8195a89d1784209d2167e1e9164d1d550e8f
+  note: Original dsputils_mmx code, which used bit-handling instead of bounds checks
 - commit: ''
   note: ''
 upvotes_instructions: |
@@ -131,7 +144,15 @@ lifetime:
           git log --stat abc..def -- your/file.c
           (where a)
       * the changelog between the two
-  answer:
+  answer: |
+    VCC1 Date:  Tue Apr 4 09:23:45 2006 +0000
+    Fix Date:   Mon Oct 9 00:32:30 2017 +0200
+    Lifetime:   ~11 years
+
+    The dsputil.c refactored... Aha. I just realized I've accidentally done a third.
+
+
+
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -242,8 +263,10 @@ subsystem:
     If this involves fixing multiple subsystems, you can make this an array.
 
     In 'answer', explain how you arrived at this determination.
-  answer:
-  name:
+  answer: |
+    Fix was applied directly to mpegvideodsp.c in avcodec, which is code that has
+    been moved around the module (within avcodec) quite a bit.
+  name: avcodec
 interesting_commits:
   question: |
     Optional: are there any interesting commits between your VCC(s) and fix(es)?
@@ -272,8 +295,8 @@ i18n:
 
     Answer should be boolean. Write a note about how you came to the conclusions
     you did.
-  answer:
-  note:
+  answer: false
+  note: Vulnerabilty had to do with render boundaries
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -361,7 +384,7 @@ CWE_instructions: |
 
   Just the number here is fine. No need for name or CWE prefix. If more than one
   apply here, then choose the best one and mention the others in CWE_note.
-CWE:
+CWE: 125
 CWE_note:
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it. If the


### PR DESCRIPTION
> Added CVE descriptions for CVE-2012-0857 and CVE-2014-8541 (buffer overflows)

(Also apologies, I had started writing CVE-2017-17081 as well but realized I didn't need to do that).